### PR TITLE
Make bot send error message if module doesn't have a manifest file

### DIFF
--- a/breadcord/core_modules/modulemanager/__init__.py
+++ b/breadcord/core_modules/modulemanager/__init__.py
@@ -78,8 +78,8 @@ class ModuleManager(breadcord.module.ModuleCog):
             if response.status != 200:
                 await interaction.response.send_message(embed=discord.Embed(
                     colour=discord.Colour.red(),
-                    title='Invalid module!',
-                    description='The repository specified does not contain a `manifest.toml` file.'
+                    title='Module not found!',
+                    description="The repository specified does not exist, can't be reached or isn't a Breadcord module."
                 ))
                 return
 

--- a/breadcord/core_modules/modulemanager/__init__.py
+++ b/breadcord/core_modules/modulemanager/__init__.py
@@ -75,6 +75,14 @@ class ModuleManager(breadcord.module.ModuleCog):
             return
 
         async with self.session.get(f'https://api.github.com/repos/{module}/contents/manifest.toml') as response:
+            if response.status != 200:
+                await interaction.response.send_message(embed=discord.Embed(
+                    colour=discord.Colour.red(),
+                    title='Invalid module!',
+                    description='The repository specified does not contain a `manifest.toml` file.'
+                ))
+                return
+
             content = (await response.json())['content']
             manifest_str = b64decode(content).decode()
             manifest = parse_manifest(tomlkit.loads(manifest_str).unwrap())


### PR DESCRIPTION
Running `/module install` with an existing, but non-module, GitHub repo as the argument would throw a `KeyError`.
This PR posts an error message embed in chat rather than throwing an exception.