### PR TITLE
fix(settings_manager): use correct setting for determining whether to send ephemeral responses

### DIFF
--- a/breadcord/core_modules/settings_manager/__init__.py
+++ b/breadcord/core_modules/settings_manager/__init__.py
@@ -51,7 +51,7 @@ class SettingsFileEditor(discord.ui.Modal, title='Settings File Editor'):
                 title='Settings saved!',
                 colour=discord.Colour.green(),
             ),
-            ephemeral=self.bot.settings.settings.ephemeral.value,
+            ephemeral=self.settings.ephemeral.value,
         )
 
 
@@ -81,7 +81,7 @@ class Settings(
                 name='In schema',
                 value=f'```py\n{setting.in_schema}\n```',
             ),
-            ephemeral=self.bot.settings.settings.ephemeral.value,
+            ephemeral=self.settings.ephemeral.value,
         )
 
     @app_commands.command(description='Set the value of a setting')
@@ -105,7 +105,7 @@ class Settings(
                 value=f'```diff\n+ {parsed_value!r}\n```',
                 inline=False,
             ),
-            ephemeral=self.bot.settings.settings.ephemeral.value,
+            ephemeral=self.settings.ephemeral.value,
         )
 
     @set.autocomplete('value')
@@ -161,7 +161,7 @@ class Settings(
         self.bot.load_settings()
         await interaction.response.send_message(
             'Settings reloaded from config file.',
-            ephemeral=self.bot.settings.settings.ephemeral.value,
+            ephemeral=self.settings.ephemeral.value,
         )
 
     @app_commands.command(description='Save bot settings to disk')
@@ -170,7 +170,7 @@ class Settings(
         self.bot.save_settings()
         await interaction.response.send_message(
             'Settings saved to config file.',
-            ephemeral=self.bot.settings.settings.ephemeral.value,
+            ephemeral=self.settings.ephemeral.value,
         )
 
 


### PR DESCRIPTION
## Bug Fix

### Checklist
<!-- Check all checkboxes that apply. These aren't required, but more is better! -->

- [x] I have run basic tests on my code to ensure it is functional.
- [x] I have thoroughly tested my code with various states, contexts and edge cases.
- [x] I have searched for a similar pull request in this repository and didn't find anything relevant.

### Summary
<!-- A clear and concise description of what changes have been made. -->

Replaces all incorrect occurrences of `self.bot.settings.settings.ephemeral.value` with `self.settings.ephemeral.value`.

### Issues
<!-- If applicable, replace the below text with a list of the issue numbers relevant to this pull request.  -->
<!-- Example:

- Fixes #42
- Fixes #27
- Related to #5

-->
- Fixes #132 

### Extra information
<!-- If applicable, replace the below text with any other relevant context and helpful information which you think may be useful. -->

(No extra information)

<!-- 🎉 Thank you for taking the time to contribute to the project! -->
