### PR TITLE
Allow specifying explicit paths as command line arguments

### DIFF
--- a/breadcord/__main__.py
+++ b/breadcord/__main__.py
@@ -9,24 +9,28 @@ parser.add_argument(
     type=Path,
     help='specify an alternative data directory to load from',
     metavar='<path>',
+    dest='data_dir',
 )
 parser.add_argument(
     '-l', '--logs',
     type=Path,
     help='specify an alternative directory to place logs in',
     metavar='<path>',
+    dest='logs_dir',
 )
 parser.add_argument(
     '-s', '--storage',
     type=Path,
     help='specify an alternative directory for modules to store data in',
     metavar='<path>',
+    dest='storage_dir',
 )
 parser.add_argument(
     '-c', '--settings', '--config',
     type=Path,
     help='specify an alternative settings file to load',
     metavar='<path>',
+    dest='setting_file',
 )
 parser.add_argument(
     '-m', '--module',
@@ -35,7 +39,7 @@ parser.add_argument(
     type=Path,
     help='specify an additional module path to load from',
     metavar='<path>',
-    dest='module_paths',
+    dest='module_dirs',
 )
 parser.add_argument(
     '-u', '--no-ui',

--- a/breadcord/__main__.py
+++ b/breadcord/__main__.py
@@ -11,6 +11,24 @@ parser.add_argument(
     metavar='<path>',
 )
 parser.add_argument(
+    '-l', '--logs',
+    type=Path,
+    help='specify an alternative directory to place logs in',
+    metavar='<path>',
+)
+parser.add_argument(
+    '-s', '--storage',
+    type=Path,
+    help='specify an alternative directory for modules to store data in',
+    metavar='<path>',
+)
+parser.add_argument(
+    '-c', '--settings', '--config',
+    type=Path,
+    help='specify an alternative settings file to load',
+    metavar='<path>',
+)
+parser.add_argument(
     '-m', '--module',
     nargs='+',
     default=[],

--- a/breadcord/bot.py
+++ b/breadcord/bot.py
@@ -48,11 +48,11 @@ class Bot(commands.Bot):
         self.settings = config.SettingsGroup('settings', observers={})
         self.ready = False
 
-        data_dir = self.args.data or Path('data')
+        data_dir = self.args.data_dir or Path('data')
         data_dir.mkdir(exist_ok=True)
         self.data_dir = data_dir.resolve()
 
-        logs_dir = self.args.logs or self.data_dir / 'logs'
+        logs_dir = self.args.logs_dir or self.data_dir / 'logs'
         logs_dir.mkdir(exist_ok=True)
         self.logs_dir = logs_dir.resolve()
 
@@ -60,11 +60,11 @@ class Bot(commands.Bot):
         modules_dir.mkdir(exist_ok=True)
         self.modules_dir = modules_dir.resolve()
 
-        storage_dir = self.args.storage or self.data_dir / 'storage'
+        storage_dir = self.args.storage_dir or self.data_dir / 'storage'
         storage_dir.mkdir(exist_ok=True)
         self.storage_dir = storage_dir.resolve()
 
-        self.settings_file = (self.args.settings or self.data_dir / 'settings.toml').resolve()
+        self.settings_file = (self.args.setting_file or self.data_dir / 'settings.toml').resolve()
 
         super().__init__(
             command_prefix=[],
@@ -145,7 +145,7 @@ class Bot(commands.Bot):
 
     async def setup_hook(self) -> None:
         search_paths = [
-            *self.args.module_paths,
+            *self.args.module_dirs,
             Path('breadcord/core_modules'),
             self.modules_dir
         ]

--- a/breadcord/bot.py
+++ b/breadcord/bot.py
@@ -51,13 +51,13 @@ class Bot(commands.Bot):
         data_dir = self.args.data or Path('data')
         data_dir.mkdir(exist_ok=True)
         self.data_dir = data_dir.resolve()
-        self.logs_dir = self.data_dir / 'logs'
+        self.logs_dir = self.args.logs or self.data_dir / 'logs'
         self.logs_dir.mkdir(exist_ok=True)
         self.modules_dir = self.data_dir / 'modules'
         self.modules_dir.mkdir(exist_ok=True)
-        self.storage_dir = self.data_dir / 'storage'
+        self.storage_dir = self.args.storage or self.data_dir / 'storage'
         self.storage_dir.mkdir(exist_ok=True)
-        self.settings_file = self.data_dir / 'settings.toml'
+        self.settings_file = self.args.settings or self.data_dir / 'settings.toml'
 
         super().__init__(
             command_prefix=[],
@@ -81,7 +81,7 @@ class Bot(commands.Bot):
 
         log_file = self.logs_dir / 'breadcord_latest.log'
         if log_file.is_file():
-            with log_file.open('r', encoding='utf-8') as file:
+            with log_file.open(encoding='utf-8') as file:
                 timestamp = file.read(10)
             try:
                 datetime.strptime(timestamp, '%Y-%m-%d')
@@ -257,12 +257,9 @@ class Bot(commands.Bot):
         self.settings = settings
 
     def save_settings(self, file_path: str | PathLike[str] | None = None) -> None:
-        if file_path is None:
-            path = self.settings_file
-        else:
-            path = Path(file_path)
+        path = self.settings_file if file_path is None else Path(file_path)
         _logger.info(f'Saving settings to {path.as_posix()}')
         path.parent.mkdir(parents=True, exist_ok=True)
         output = self.settings.as_toml().as_string().rstrip() + '\n'
-        with path.open('w+', encoding='utf-8') as file:
+        with path.open('w', encoding='utf-8') as file:
             file.write(output)

--- a/breadcord/bot.py
+++ b/breadcord/bot.py
@@ -51,13 +51,20 @@ class Bot(commands.Bot):
         data_dir = self.args.data or Path('data')
         data_dir.mkdir(exist_ok=True)
         self.data_dir = data_dir.resolve()
-        self.logs_dir = self.args.logs or self.data_dir / 'logs'
-        self.logs_dir.mkdir(exist_ok=True)
-        self.modules_dir = self.data_dir / 'modules'
-        self.modules_dir.mkdir(exist_ok=True)
-        self.storage_dir = self.args.storage or self.data_dir / 'storage'
-        self.storage_dir.mkdir(exist_ok=True)
-        self.settings_file = self.args.settings or self.data_dir / 'settings.toml'
+
+        logs_dir = self.args.logs or self.data_dir / 'logs'
+        logs_dir.mkdir(exist_ok=True)
+        self.logs_dir = logs_dir.resolve()
+
+        modules_dir = self.data_dir / 'modules'
+        modules_dir.mkdir(exist_ok=True)
+        self.modules_dir = modules_dir.resolve()
+
+        storage_dir = self.args.storage or self.data_dir / 'storage'
+        storage_dir.mkdir(exist_ok=True)
+        self.storage_dir = storage_dir.resolve()
+
+        self.settings_file = (self.args.settings or self.data_dir / 'settings.toml').resolve()
 
         super().__init__(
             command_prefix=[],


### PR DESCRIPTION
In combination with 65cc205 this closes #61.

Adds support for specifying paths for the logs and storage directories as command line arguments, as well as the path for the settings file.

Changes have been tested.