### PR TITLE
Fix requirement install

### DIFF
--- a/breadcord/module.py
+++ b/breadcord/module.py
@@ -77,10 +77,10 @@ class Module:
                     return False
             return True
 
-        if missing_requirements := filter(
+        if missing_requirements := set(filter(
             is_missing,
             self.manifest.requirements,
-        ):
+        )):
             subprocess.check_call([sys.executable, '-m', 'pip', 'install', *missing_requirements])  # noqa: S603
 
 

--- a/breadcord/module.py
+++ b/breadcord/module.py
@@ -77,10 +77,7 @@ class Module:
                     return False
             return True
 
-        if missing_requirements := set(filter(
-            is_missing,
-            self.manifest.requirements,
-        )):
+        if missing_requirements := tuple(filter(is_missing, self.manifest.requirements)):
             subprocess.check_call([sys.executable, '-m', 'pip', 'install', *missing_requirements])  # noqa: S603
 
 


### PR DESCRIPTION
## Bug Fix
### Summary
Fixes an error when no module requirements need to be installed.

### Extra information
This was broken in #144 since a filter object is always truthy, this simply wraps it in a set.
