### PR TITLE
Run breadcord action

### DIFF
--- a/.github/workflows/run_breadcord.yml
+++ b/.github/workflows/run_breadcord.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: pip install -Ur requirements.txt
 
-      - name: Generate config and set the config
+      - name: Generate config and set token
         shell: bash
         env:
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/run_breadcord.yml
+++ b/.github/workflows/run_breadcord.yml
@@ -1,0 +1,39 @@
+name: Run breadcord
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+jobs:
+  run:
+    name: Run Breadcord
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout repository
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
+        run: pip install -Ur requirements.txt
+
+      - name: Generate config and set the config
+        shell: bash
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: |
+          python tests/setup_breadcord.py "$BOT_TOKEN"
+
+      - name: Run breadcord without the TUI
+        run: |
+          timeout --preserve-status 10 python -m breadcord --no-ui \
+          || ([[ $? -eq 143 ]] && echo "Breadcord was terminated")
+
+      - name: Run breadcord with the TUI
+        run: |
+          timeout --preserve-status 10 python -m breadcord \
+          || ([[ $? -eq 143 ]] && echo "Breadcord was terminated")

--- a/tests/setup_breadcord.py
+++ b/tests/setup_breadcord.py
@@ -1,0 +1,25 @@
+import argparse
+import subprocess
+from pathlib import Path
+
+from tomlkit.toml_file import TOMLFile
+
+SETTINGS_PATH = Path("data/settings.toml")
+
+
+def set_token(token: str) -> None:
+    if not token:
+        raise ValueError('Token cannot be empty')
+
+    settings = TOMLFile(SETTINGS_PATH).read()
+    settings["token"] = token
+    TOMLFile(SETTINGS_PATH).write(settings)
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('token', type=str)
+parsed_args = parser.parse_args()
+
+if __name__ == '__main__':
+    process = subprocess.run(("python", "-m", "breadcord", '--no-ui'), timeout=10)
+    set_token(parsed_args.token)


### PR DESCRIPTION
## New Feature

### Checklist
<!-- Check all checkboxes that apply. These aren't required, but more is better! -->

- [ ] I have planned and discussed this feature with other contributors.
- [x] I have run basic tests on my code to ensure it is functional.
- [x] I have thoroughly tested my code with various states, contexts and edge cases.
- [x] I have searched for a similar pull request in this repository and didn't find anything relevant.

### Summary
Adds an action to run breadcord both with and without the TUI to ensure that it still runs with the latest changes. This should hopefully stop mistakes like that fixed in #150 from making it to main.

### Issues
(No related issues)

### Extra information
This requires a `BOT_TOKEN` secret to be set in the repo.
