### PR TITLE
Modulecog session

### DIFF
--- a/breadcord/helpers.py
+++ b/breadcord/helpers.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import inspect
 import sys
 from collections import defaultdict
-from typing import TYPE_CHECKING, Callable, TypeVar, overload
+from typing import TYPE_CHECKING, Callable, TypeVar, overload, Self
 
 import aiohttp
 import discord
 from rapidfuzz.fuzz import partial_ratio_alignment
-from typing_extensions import Self
 
 import breadcord
 from breadcord.module import ModuleCog

--- a/breadcord/helpers.py
+++ b/breadcord/helpers.py
@@ -215,8 +215,10 @@ class ModuleSessionCog(breadcord.module.ModuleCog):
         self.session: aiohttp.ClientSession = None  # type: ignore
 
     async def cog_load(self) -> None:
+        await super().cog_load()
         self.session = aiohttp.ClientSession()
 
     async def cog_unload(self) -> None:
+        await super().cog_unload()
         if self.session is not None and not self.session.closed:
             await self.session.close()

--- a/breadcord/helpers.py
+++ b/breadcord/helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import sys
 from collections import defaultdict
 from typing import TYPE_CHECKING, Callable, TypeVar, overload
 
@@ -212,6 +213,12 @@ class HTTPModuleCog(breadcord.module.ModuleCog):
     def __init__(self, *args, headers: aiohttp.typedefs.LooseHeaders | None = None, **kwargs):
         super().__init__(*args, **kwargs)
 
+        headers['User-Agent'] = headers.get('User-Agent') or (
+            f'Breadcord (https://breadcord.com/) '
+            f'{self.module.manifest.id}/{self.module.manifest.version} '
+            f'Python/{".".join(map(str, sys.version_info[:3]))} '
+            f'aiohttp/{aiohttp.__version__}'
+        )
         self._session_headers = headers
         # White lie since the type checker doesn't know about cog_load
         self.session: aiohttp.ClientSession = None  # type: ignore[assignment]

--- a/breadcord/helpers.py
+++ b/breadcord/helpers.py
@@ -212,7 +212,7 @@ class ModuleSessionCog(breadcord.module.ModuleCog):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # White lie since the type checker doesn't know about cog_load
-        self.session: aiohttp.ClientSession = None  # type: ignore
+        self.session: aiohttp.ClientSession = None  # type: ignore[assignment]
 
     async def cog_load(self) -> None:
         await super().cog_load()

--- a/breadcord/helpers.py
+++ b/breadcord/helpers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 import sys
 from collections import defaultdict
-from typing import TYPE_CHECKING, Callable, TypeVar, overload, Self
+from typing import TYPE_CHECKING, Callable, Self, TypeVar, overload
 
 import aiohttp
 import discord

--- a/breadcord/helpers.py
+++ b/breadcord/helpers.py
@@ -209,14 +209,16 @@ def simple_transformer(to: type[_T]) -> Callable[[type[_Transformer]], _Transfor
 class HTTPModuleCog(breadcord.module.ModuleCog):
     """A module cog which automatically creates and closes an aiohttp session."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, headers: aiohttp.typedefs.LooseHeaders | None = None, **kwargs):
         super().__init__(*args, **kwargs)
+
+        self._session_headers = headers
         # White lie since the type checker doesn't know about cog_load
         self.session: aiohttp.ClientSession = None  # type: ignore[assignment]
 
     async def cog_load(self) -> None:
         await super().cog_load()
-        self.session = aiohttp.ClientSession()
+        self.session = aiohttp.ClientSession(headers=self._session_headers)
 
     async def cog_unload(self) -> None:
         await super().cog_unload()

--- a/breadcord/helpers.py
+++ b/breadcord/helpers.py
@@ -206,7 +206,7 @@ def simple_transformer(to: type[_T]) -> Callable[[type[_Transformer]], _Transfor
     return decorator
 
 
-class ModuleSessionCog(breadcord.module.ModuleCog):
+class HTTPModuleCog(breadcord.module.ModuleCog):
     """A module cog which automatically creates and closes an aiohttp session."""
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## New Feature

### Checklist
- [ ] I have planned and discussed this feature with other contributors.
- [x] I have run basic tests on my code to ensure it is functional.
- [ ] I have thoroughly tested my code with various states, contexts and edge cases.
- [x] I have searched for a similar pull request in this repository and didn't find anything relevant.

### Summary
Adds a `ModuleSessionCog` class to the helpers which inherits from `breadcord.module.ModuleCog` and provides a `session` attribute holding an `aiohttp.ClientSession`.

### Issues
(No related issues)

### Extra information
This was done since interacting with an external API is an extreemely common thing for a module to need to do, and this should remove some boilerplate.
