### PR TITLE
Remove warning if module id does not match directory name

### DIFF
--- a/breadcord/module.py
+++ b/breadcord/module.py
@@ -37,8 +37,6 @@ class Module:
         self.manifest = parse_manifest(config.load_settings(self.path / 'manifest.toml'))
 
         self.id = self.manifest.id
-        if self.id != self.path.name:
-            self.logger.warning(f"Module ID '{self.id}' does not match directory name")
 
     @property
     def storage_path(self) -> Path:


### PR DESCRIPTION
Never should one rely on a module's id being the same as its directory name, so this warning serves no purpose but to clutter the startup logs.