### PR TITLE
Allow passing specific modules to update

### DIFF
--- a/breadcord/core_modules/auto_update/__init__.py
+++ b/breadcord/core_modules/auto_update/__init__.py
@@ -11,11 +11,10 @@ from discord.ext import commands, tasks
 
 import breadcord
 from breadcord.helpers import make_codeblock
+from breadcord.module import Module  # noqa: TCH001
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-
-    from breadcord.module import Module
 
 
 class ModulesConverter(commands.Converter):
@@ -154,10 +153,17 @@ class AutoUpdate(breadcord.module.ModuleCog):
     async def update(
         self,
         ctx: commands.Context,
-        modules: Annotated[list[Module], ModulesConverter],
+        # A bit of a misleading name, but it makes more sense for users
+        module_ids: Annotated[list[Module], ModulesConverter],
     ) -> None:
+        """Update one or more modules to the latest commit on the remote repository.
+
+        If no modules are specified, all loaded modules will be updated.
+        If module IDs are specified, only those modules will be updated, regardless of whether they are loaded.
+        If `all` or `*` is specified, all modules will be updated regardless of whether they are loaded.
+        """
         response = await ctx.send('Updating...')
-        updated = await self.update_modules([module.id for module in modules] if modules else None)
+        updated = await self.update_modules([module.id for module in module_ids] if module_ids else None)
         if len(updated) == 0:
             await response.edit(content='No modules were updated.')
             return

--- a/breadcord/core_modules/auto_update/__init__.py
+++ b/breadcord/core_modules/auto_update/__init__.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 from collections.abc import Iterable
 from functools import cache
-from typing import Any, Annotated
+from typing import Annotated, Any
 
 import discord
 from discord.ext import commands, tasks

--- a/breadcord/core_modules/auto_update/__init__.py
+++ b/breadcord/core_modules/auto_update/__init__.py
@@ -3,14 +3,25 @@ from __future__ import annotations
 import asyncio
 import shutil
 import subprocess
+from collections.abc import Iterable
 from functools import cache
-from typing import Any
+from typing import Any, Annotated
 
 import discord
 from discord.ext import commands, tasks
 
 import breadcord
 from breadcord.helpers import make_codeblock
+from breadcord.module import Module
+
+
+class ModuleConverter(commands.Converter):
+    async def convert(self, ctx: commands.Context, argument: str) -> Module:
+        argument = argument.strip().lower()
+        bot: breadcord.Bot = ctx.bot
+        if argument not in bot.modules:
+            raise commands.BadArgument(f'Module {argument!r} not found')
+        return bot.modules.get(argument)
 
 
 @cache
@@ -38,7 +49,7 @@ async def git(*command_arguments: str, timeout: float = 10, **kwargs: Any) -> st
     stdout, stderr = await process.communicate()
     if process.returncode != 0:
         raise subprocess.CalledProcessError(
-            process.returncode,
+            process.returncode if process.returncode is not None else -1,
             ' '.join(map(str, (git_path(), *command_arguments))),
             output=stdout.decode(),
             stderr=stderr.decode(),
@@ -53,7 +64,7 @@ class AutoUpdate(breadcord.module.ModuleCog):
         self.loop = None
 
     async def cog_load(self) -> None:
-        @self.settings.update_interval.observe
+        @self.settings.update_interval.observe  # type: ignore[arg-type]
         def on_update_interval_changed(_, new: float) -> None:
             if self.loop is not None:
                 self.loop.stop()
@@ -65,43 +76,60 @@ class AutoUpdate(breadcord.module.ModuleCog):
         async def wait_for_ready():
             while not self.bot.ready:
                 await asyncio.sleep(1)
-            on_update_interval_changed(0, self.settings.update_interval.value)
+            on_update_interval_changed(0, self.settings.update_interval.value)  # type: ignore[arg-type]
         task = asyncio.create_task(wait_for_ready())
         task.add_done_callback(lambda _: self.logger.debug('Auto update task scheduled and ran'))
 
-    async def update_modules(self) -> dict[str, tuple[str, str, str]]:
+    async def update_modules(self, module_ids: Iterable[str] | None = None) -> dict[str, tuple[str, str, str]]:
+        to_update = set(module_ids) if module_ids else set(module.id for module in self.bot.modules if module.loaded)
+        not_found = tuple(module_id for module_id in to_update if module_id not in self.bot.modules)
+        if not_found:
+            self.logger.warning(f'Modules not found: {", ".join(not_found)}')
+
         updated_modules = {}
         self.logger.info('Attempting to update modules')
         for module in self.bot.modules:
+            if module.id not in to_update:
+                continue
             if not module.loaded:
                 continue
-            if not (module.path / '.git' / 'HEAD').is_file():
+            if not await self.should_update(module):
                 continue
             try:
-                await git('fetch', cwd=module.path)
-                ahead = (await git('rev-list', '--count', '@{u}..HEAD', cwd=module.path)).strip()
-                behind = (await git('rev-list', '--count', 'HEAD..@{u}', cwd=module.path)).strip()
-
-                if ahead != '0':
-                    self.logger.warning(f'Module {module.id} is ahead of the remote repository by {ahead} commits.')
-                    continue
-                if behind == '0':
-                    self.logger.debug(f'Module {module.id} is up-to-date.')
-                    continue
-                self.logger.warning(f'Module {module.id} is out-of-date by {behind} commits.')
-
                 pull_msg, commit_hash, commit_msg = await self.update_module(module)
                 updated_modules[module.id] = pull_msg, commit_hash, commit_msg
             except subprocess.CalledProcessError as error:
-                self.logger.error(f'Failed to fetch updates for the module {module.id!r}: {error}\n{error.stderr}')
+                self.logger.error(f'Failed to update module {module.id!r}: {error}\n{error.stderr}')
 
         if updated_modules:
-            self.logger.info(f'Finished updating {len(updated_modules)} modules')
+            self.logger.info(f'Finished updating len({updated_modules}) modules')
         else:
             self.logger.debug('No modules were updated')
         return updated_modules
 
-    async def update_module(self, module: breadcord.module.Module) -> tuple[str, str, str]:
+    async def should_update(self, module: Module) -> bool:
+        """Check if the module can safely be updated to the latest commit on the remote repository."""
+        if not (module.path / '.git' / 'HEAD').is_file():
+            return False
+        try:
+            await git('fetch', cwd=module.path)
+            ahead = (await git('rev-list', '--count', '@{u}..HEAD', cwd=module.path)).strip()
+            behind = (await git('rev-list', '--count', 'HEAD..@{u}', cwd=module.path)).strip()
+        except subprocess.CalledProcessError as error:
+            self.logger.error(f'Failed to check for updates for the module {module.id!r}: {error}\n{error.stderr}')
+            return False
+
+        if ahead != '0':
+            self.logger.warning(f'Module {module.id} is ahead of the remote repository by {ahead} commits.')
+            return False
+        if behind == '0':
+            self.logger.debug(f'Module {module.id} is up-to-date.')
+            return False
+        self.logger.debug(f'Module {module.id} is out-of-date by {behind} commits.')
+        return True
+
+    async def update_module(self, module: Module) -> tuple[str, str, str]:
+        """Update a module to the latest commit on the remote repository."""
         self.logger.info(f'Updating {module.id}')
         update_text = await git('pull', cwd=module.path)
         self.logger.debug(f'({module.id}) Git output:\n{update_text.strip()}')
@@ -115,11 +143,15 @@ class AutoUpdate(breadcord.module.ModuleCog):
 
     @commands.command()
     @commands.is_owner()
-    async def update(self, ctx: commands.Context) -> None:
-        message = await ctx.send('Updating...')
-        updated = await self.update_modules()
+    async def update(
+        self,
+        ctx: commands.Context,
+        modules: Annotated[list[Module], commands.Greedy[ModuleConverter]],
+    ) -> None:
+        response = await ctx.send('Updating...')
+        updated = await self.update_modules([module.id for module in modules] if modules else None)
         if len(updated) == 0:
-            await message.edit(content='No modules were updated.')
+            await response.edit(content='No modules were updated.')
             return
 
         commit_message_length = 1000
@@ -130,7 +162,6 @@ class AutoUpdate(breadcord.module.ModuleCog):
                 commit_msg = f'{commit_msg[:commit_message_length]}...'  # noqa: PLW2901  # Would be effort to fix
             if len(pull_msg) > pull_message_length:
                 pull_msg = f'{pull_msg[:pull_message_length]}...'        # noqa: PLW2901  # Would be effort to fix
-
             embeds.append(
                 discord.Embed(
                     title=f'Updated module `{module_id}`',
@@ -141,7 +172,6 @@ class AutoUpdate(breadcord.module.ModuleCog):
                     color=discord.Colour.green(),
                 ).set_footer(text=f'Now on commit {commit_hash}'),
             )
-
         max_embeds = 10
         if len(embeds) > max_embeds:
             embeds = embeds[:max_embeds]
@@ -150,7 +180,7 @@ class AutoUpdate(breadcord.module.ModuleCog):
                 description=f'{len(updated) - len(embeds)} more modules were updated.',
                 color=discord.Colour.orange(),
             ))
-        await message.edit(
+        await response.edit(
             content='Finished updating modules.',
             embeds=embeds,
         )


### PR DESCRIPTION
## New Feature

### Checklist
- [ ] I have planned and discussed this feature with other contributors.
- [ ] I have run basic tests on my code to ensure it is functional.
- [ ] I have thoroughly tested my code with various states, contexts and edge cases.
- [x] I have searched for a similar pull request in this repository and didn't find anything relevant.

### Summary
Allows specifying which modules to update with the `update` command.
Syntax: `update module_id1 module_id2 module_id3`

### Issues
(No related issues)

### Extra information
(No extra information)
