### PR TITLE
Ruff 0.5.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.10
+    rev: v0.5.0
     hooks:
       - id: ruff
         args: [ --fix ]

--- a/breadcord/config.py
+++ b/breadcord/config.py
@@ -112,7 +112,7 @@ class Setting(SettingsNode):
     @value.setter
     def value(self, new_value: Any) -> None:
         """Assign a new value to the setting, validating the new value type and triggering necessary observers."""
-        if isinstance(new_value, int) and self.type == float:
+        if isinstance(new_value, int) and self.type == float:  # noqa: E721
             new_value = float(new_value)
         if not isinstance(new_value, self.type):
             raise TypeError(
@@ -265,7 +265,7 @@ class SettingsGroup(SettingsNode):
                 continue
 
             setting = parse_schema_chunk(chunk)
-            if setting.type == dict:
+            if setting.type == dict:  # noqa: E721
                 group = self.get_child(setting.key, allow_new=True)
                 group.description = setting.description
                 group.in_schema = True

--- a/breadcord/core_modules/auto_update/__init__.py
+++ b/breadcord/core_modules/auto_update/__init__.py
@@ -35,8 +35,8 @@ def git_path() -> str:
     if not (path := shutil.which('git')):
         raise FileNotFoundError('git executable not found')
     # A bit of blocking is fine here since this should only be uncached when the module first starts
-    subprocess.check_call(
-        [path, '--version'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=5,  # noqa: S603
+    subprocess.check_call(  # noqa: S603
+        [path, '--version'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=5,
     )
     return path
 

--- a/breadcord/core_modules/settings_manager/__init__.py
+++ b/breadcord/core_modules/settings_manager/__init__.py
@@ -122,14 +122,14 @@ class Settings(
         current_str = tomlkit.item(setting.value).as_string()
         autocomplete = [app_commands.Choice(name=current_str, value=current_str)]
 
-        if setting.type == int:
+        if setting.type == int:  # noqa: E721
             current = current or '0'
             try:
                 autocomplete.append(app_commands.Choice(name=f'(integer) {int(current)}', value=current))
             except ValueError:
                 return [app_commands.Choice(name=f"⚠️ Invalid integer '{current}'", value=current)]
 
-        elif setting.type == str:
+        elif setting.type == str:  # noqa: E721
             if current[0] + current[-1] in ('""', "''"):
                 current = current[1:-1]
             autocomplete.append(app_commands.Choice(
@@ -137,7 +137,7 @@ class Settings(
                 value=tomlkit.item(current).as_string(),
             ))
 
-        elif setting.type == bool:
+        elif setting.type == bool:  # noqa: E721
             autocomplete.extend(booleans := [
                 app_commands.Choice(name=f'(boolean) {choice}', value=choice)
                 for choice in ('false', 'true')


### PR DESCRIPTION
Fixes all errors caused by modern ruff -- all of which happen to be irrelevant.
Most of the errors are https://docs.astral.sh/ruff/rules/type-comparison/