### PR TITLE
Asynchronously load modules and use uv to install deps

### DIFF
--- a/breadcord/module.py
+++ b/breadcord/module.py
@@ -113,12 +113,12 @@ class Module:
         self.logger.info('Installing missing requirements: ' + ', '.join(req.name for req in missing_requirements))
 
         if shutil.which('uv'):
-            cmd = ["uv", 'pip', 'install', "--python", sys.executable, *map(str, missing_requirements)]
+            cmd = ['uv', 'pip', 'install', '--python', sys.executable, *map(str, missing_requirements)]
         else:
             cmd = [sys.executable, '-m', 'pip', 'install', *map(str, missing_requirements)]
             self.logger.warning(
-                "uv is not installed, using it is the preferred way to install module requirements. "
-                "Falling back to pip."
+                'uv is not installed, using it is the preferred way to install module requirements. '
+                'Falling back to pip.',
             )
         process = await asyncio.create_subprocess_exec(
             *cmd,

--- a/breadcord/module.py
+++ b/breadcord/module.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import importlib.metadata
 import logging
+import shutil
 import subprocess
 import sys
 from logging import getLogger
@@ -111,7 +112,14 @@ class Module:
             return
         self.logger.info('Installing missing requirements: ' + ', '.join(req.name for req in missing_requirements))
 
-        cmd = [sys.executable, '-m', 'pip', 'install', *map(str, missing_requirements)]
+        if shutil.which('uv'):
+            cmd = ["uv", 'pip', 'install', "--python", sys.executable, *map(str, missing_requirements)]
+        else:
+            cmd = [sys.executable, '-m', 'pip', 'install', *map(str, missing_requirements)]
+            self.logger.warning(
+                "uv is not installed, using it is the preferred way to install module requirements. "
+                "Falling back to pip."
+            )
         process = await asyncio.create_subprocess_exec(
             *cmd,
             stdout=subprocess.PIPE,
@@ -127,7 +135,7 @@ class Module:
             log_stream(process.stderr, self.logger.error),
         )
         return_code = await process.wait()
-        if return_code:
+        if return_code != 0:
             self.logger.error(f'Failed to install requirements with exit code {return_code}')
             raise subprocess.CalledProcessError(return_code, cmd)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "rich==13.7.1",
     "textual==0.71.0",
     "tomlkit==0.12.5",
+    "uv==0.2.21",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## New Feature

### Checklist
<!-- Check all checkboxes that apply. These aren't required, but more is better! -->

- [x] I have planned and discussed this feature with other contributors.
- [x] I have run basic tests on my code to ensure it is functional.
- [ ] I have thoroughly tested my code with various states, contexts and edge cases.
- [x] I have searched for a similar pull request in this repository and didn't find anything relevant.

### Summary
Makes module loading actually happen asynchronously. With this, uv has been added as a (at the moment technically optional) dependency.

### Related PRs
Continuation of #238

### Extra information
Uv was added as a dependency in an attempt to solve the crashing problem reported by @ThatOtherAndrew in #238. I've personally been unable to replicate the reported behaviour though, so I can't speak for if it's been properly resolved.

There might be issues caused by using both uv and pip in a single virtual environment, something I have not tested extensively.
