### PR TITLE
Pass module to extension setup function for less duplication

### DIFF
--- a/breadcord/module.py
+++ b/breadcord/module.py
@@ -74,12 +74,12 @@ class Module:
     async def load(self) -> None:
         self.load_settings_schema()
         await self.install_requirements()
-        await self.bot.load_extension(self.import_string)
+        await self.bot.load_module(self)
         self.loaded = True
         self.logger.info('Module successfully loaded')
 
     async def unload(self) -> None:
-        await self.bot.unload_extension(self.import_string)
+        await self.bot.unload_module(self)
         self.loaded = False
         self.logger.info('Module successfully unloaded')
 
@@ -87,7 +87,7 @@ class Module:
         self.loaded = False
         self.load_settings_schema()
         await self.install_requirements()
-        await self.bot.reload_extension(self.import_string)
+        await self.bot.reload_module(self)
         self.loaded = True
         self.logger.info('Module successfully reloaded')
 


### PR DESCRIPTION
## New Feature

### Checklist
<!-- Check all checkboxes that apply. These aren't required, but more is better! -->

- [ ] I have planned and discussed this feature with other contributors.
- [x] I have run basic tests on my code to ensure it is functional.
- [ ] I have thoroughly tested my code with various states, contexts and edge cases.
- [x] I have searched for a similar pull request in this repository and didn't find anything relevant.

### Summary
<!-- A clear and concise description of what changes have been made. -->
Passes the module instance to extension setup functions so we don't have to duplicate what is already in the manifest
```python
class Example(ModuleCog):
    def __init__(self, module_id) -> None:
        super().__init__(module_id)

async def setup(bot: breadcord.Bot, module: Module) -> None:
    await bot.add_cog(Example(module.id))
```

