### PR TITLE
Add Module and ModuleCog to breadcord __init__

### DIFF
--- a/breadcord/__init__.py
+++ b/breadcord/__init__.py
@@ -1,2 +1,3 @@
 from . import config, errors, helpers, module
 from .bot import Bot
+from .module import Module, ModuleCog


### PR DESCRIPTION
## New Feature

### Checklist
<!-- Check all checkboxes that apply. These aren't required, but more is better! -->

- [ ] I have planned and discussed this feature with other contributors.
- [x] I have run basic tests on my code to ensure it is functional.
- [ ] I have thoroughly tested my code with various states, contexts and edge cases.
- [x] I have searched for a similar pull request in this repository and didn't find anything relevant.

### Summary
Adds imports for `breadcord.module.Module` and `breadcord.module.ModuleCog` to `breadcord/__init__.py` in order to make common imports easier to access.

### Testing
No cyclic imports should be caused by this change, and from testing the bot loads fine with a minimal set of modules.
