### PR TITLE
Remove duplicate module entries in settings upon bot load

### DIFF
--- a/breadcord/bot.py
+++ b/breadcord/bot.py
@@ -190,7 +190,7 @@ class Bot(commands.Bot):
             )
             modules = self.settings.modules.value = unduped
 
-        await asyncio.gather(*(load_wrapper(module) for module in modules))
+        await asyncio.gather(*map(load_wrapper, modules))
 
         @self.settings.command_prefixes.observe
         def on_command_prefixes_changed(_, new: list[str]) -> None:

--- a/breadcord/bot.py
+++ b/breadcord/bot.py
@@ -186,7 +186,7 @@ class Bot(commands.Bot):
         if len(modules) != len(unduped):
             _logger.warning(
                 f'Duplicate module entries found in settings. '
-                f'Removing {len(modules) - len(unduped)} duplicate(s).'
+                f'Removing {len(modules) - len(unduped)} duplicate(s).',
             )
             modules = self.settings.modules.value = unduped
 


### PR DESCRIPTION
The bot would otherwise crash quite late into loading.