### PR TITLE
Type settings

### DIFF
--- a/breadcord/config.py
+++ b/breadcord/config.py
@@ -74,7 +74,7 @@ class SettingsNode:
         node = self
         while node.parent is not None:
             node = node.parent
-        # This shouldntever  be possible, but we want the type checker to be happy :D
+        # This should never be possible, but we want the type checker to be happy :D
         if __debug__ and not isinstance(node, SettingsGroup):
             raise ValueError('root node is not a SettingsGroup')
         return cast(SettingsGroup, node)

--- a/breadcord/config.py
+++ b/breadcord/config.py
@@ -74,6 +74,7 @@ class SettingsNode:
         node = self
         while node.parent is not None:
             node = node.parent
+        # This shouldntever  be possible, but we want the type checker to be happy :D
         if __debug__ and not isinstance(node, SettingsGroup):
             raise ValueError('root node is not a SettingsGroup')
         return cast(SettingsGroup, node)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ select = [
     "F",        # pyflakes
     "W",        # pycodestyle warnings
     "E",        # pycodestyle errors
-    "C90",      # mccabe
     "I",        # isort
     "N",        # pep8-naming
     "D",        # pydocstyle


### PR DESCRIPTION
## Enhancement

### Checklist
- [ ] I have planned and discussed this feature with other contributors.
- [x] I have run basic tests on my code to ensure it is functional.
- [ ] I have thoroughly tested my code with various states, contexts and edge cases.
- [x] I have searched for a similar pull request in this repository and didn't find anything relevant.

### Summary
<!-- A clear and concise description of what changes have been made. -->

Cleans up a lot of typing issues, and makes `breadcord.config.Setting` into a generic.
This means that doing something like this would now be marked as invalid by the type checker due to a type mismatch.
```py
my_setting = cast(breadcord.config.Setting[bool], self.settings.my_setting)
@my_setting.observe
def observer(_, new: str) -> None:
    ...
```
