### PR TITLE
App emoji management

### DIFF
--- a/breadcord/bot.py
+++ b/breadcord/bot.py
@@ -35,7 +35,7 @@ module_path = Path(__file__).parent
 
 def _get_emoji_name(module: Module, path: Path, data: bytes) -> str:
     file_hash = hashlib.md5(data).hexdigest()
-    return f"{module.id}_{path.stem}__{file_hash[:6]}"
+    return f'{module.id}_{path.stem}__{file_hash[:6]}'
 
 
 class CommandTree(discord.app_commands.CommandTree):

--- a/breadcord/bot.py
+++ b/breadcord/bot.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import importlib.machinery
 import importlib.util
 import inspect
 import logging
+import os.path
 import sys
+from collections.abc import Awaitable
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import aiofiles
 import discord
 from discord.ext import commands
 from discord.ext.commands.view import StringView
@@ -27,6 +31,11 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger('breadcord.bot')
 module_path = Path(__file__).parent
+
+
+def _get_emoji_name(module: Module, path: Path, data: bytes) -> str:
+    file_hash = hashlib.md5(data).hexdigest()
+    return f"{module.id}_{path.stem}__{file_hash[:6]}"
 
 
 class CommandTree(discord.app_commands.CommandTree):
@@ -50,6 +59,8 @@ class Bot(commands.Bot):
         self.tui = tui_app
         self.args = args
         self.settings = config.SettingsGroup('settings', observers={})
+        self._registered_emojis: dict[tuple[Module, Path], discord.PartialEmoji] = {}
+        # self._cached_application_emojis: set[discord.PartialEmoji] = set()
         self.ready = False
         self._new_data_dir = False
 
@@ -180,6 +191,24 @@ class Bot(commands.Bot):
         @self.settings.administrators.observe
         def on_administrators_changed(_, new: list[int]) -> None:
             self.owner_ids = set(new)
+
+        async def run_when_ready(coroutine: Awaitable) -> None:
+            await self.wait_until_ready()
+            await coroutine
+
+        self.loop.create_task(run_when_ready(self.on_first_connect()))
+
+    async def on_first_connect(self) -> None:
+        application_emojis = await self.fetch_application_emojis()
+
+        for module, path in dict(self._registered_emojis):  # Copy
+            async with aiofiles.open(path, 'rb') as file:
+                name = _get_emoji_name(module, path, await file.read())
+            emoji = discord.utils.get(application_emojis, name=name)
+            if emoji is None:
+                await self.register_custom_emoji(module, path)
+            else:
+                _logger.debug(f'Emoji {emoji} found from {path.relative_to(self.data_dir).as_posix()}')
 
     async def load_modules(self) -> None:
         modules: list[str] = self.settings.modules.value
@@ -404,3 +433,34 @@ class Bot(commands.Bot):
             self._BotBase__extensions[name] = lib
             sys.modules.update(modules)
             raise
+
+    async def register_custom_emoji(self, module: Module, path: Path) -> discord.PartialEmoji:
+        if os.path.getsize(path) > 256*1024: # 256 KiB
+            raise ValueError(f'Emojis cannot be larger than 256 KiB: {path.as_posix()}')
+
+        # We use this method before the bot is ready, and deal with that in on_first_connect
+        if not self.ready:
+            partial = discord.PartialEmoji(
+                name=path.stem,
+                id=None,
+                animated=path.suffix == '.gif',
+            )
+            self._registered_emojis[(module, path)] = partial
+            return partial
+
+        if (module, path) in self._registered_emojis:
+            del self._registered_emojis[(module, path)]  # Might error when adding
+
+        async with aiofiles.open(path, 'rb') as file:
+            img_data = await file.read()
+        name = _get_emoji_name(module, path, img_data)
+
+        emoji = await self.create_application_emoji(name=name, image=img_data)
+        partial = discord.PartialEmoji(
+            name=emoji.name,
+            id=emoji.id,
+            animated=emoji.animated,
+        )
+        _logger.debug(f'Emoji {partial} registered from {path.relative_to(self.data_dir).as_posix()}')
+        self._registered_emojis[(module, path)] = partial  # It didn't error
+        return partial

--- a/breadcord/module.py
+++ b/breadcord/module.py
@@ -17,7 +17,6 @@ import tomlkit
 from discord.ext import commands
 from packaging.requirements import Requirement
 from packaging.version import Version
-import aiofiles
 
 from breadcord import config
 

--- a/breadcord/module.py
+++ b/breadcord/module.py
@@ -144,12 +144,15 @@ class Module:
             raise subprocess.CalledProcessError(return_code, cmd)
 
     async def register_emoji(self, path: str | PathLike[str]) -> discord.PartialEmoji:
+        """Register a custom application emoji. Returned emoji objects will not have an ID if registered before bot ready."""
         return await self.bot.register_custom_emoji(self, Path(path).resolve())
 
     async def register_emojis(self, *paths: str | PathLike[str]) -> list[discord.PartialEmoji]:
+        """Register multiple custom application emojis. Returned emoji objects will not have an ID if registered before bot ready."""
         return [await self.register_emoji(path) for path in paths]
 
     def get_emoji(self, path: str | PathLike[str]) -> discord.PartialEmoji | None:
+        """Get a custom application emoji by path. Returns None if the emoji is not registered."""
         # noinspection PyProtectedMember
         return self.bot._registered_emojis.get((self, Path(path).resolve()))
 

--- a/breadcord/module.py
+++ b/breadcord/module.py
@@ -17,6 +17,7 @@ import tomlkit
 from discord.ext import commands
 from packaging.requirements import Requirement
 from packaging.version import Version
+import aiofiles
 
 from breadcord import config
 
@@ -141,6 +142,16 @@ class Module:
         if return_code != 0:
             self.logger.error(f'Failed to install requirements with exit code {return_code}')
             raise subprocess.CalledProcessError(return_code, cmd)
+
+    async def register_emoji(self, path: str | PathLike[str]) -> discord.PartialEmoji:
+        return await self.bot.register_custom_emoji(self, Path(path).resolve())
+
+    async def register_emojis(self, *paths: str | PathLike[str]) -> list[discord.PartialEmoji]:
+        return [await self.register_emoji(path) for path in paths]
+
+    def get_emoji(self, path: str | PathLike[str]) -> discord.PartialEmoji | None:
+        # noinspection PyProtectedMember
+        return self.bot._registered_emojis.get((self, Path(path).resolve()))
 
 
 class Modules:


### PR DESCRIPTION
## New Feature

### Checklist
<!-- Check all checkboxes that apply. These aren't required, but more is better! -->

- [x] I have planned and discussed this feature with other contributors.
- [x] I have run basic tests on my code to ensure it is functional.
- [ ] I have thoroughly tested my code with various states, contexts and edge cases.
- [x] I have searched for a similar pull request in this repository and didn't find anything relevant.

### Summary
Allows modules to register their own [application emojis](https://github.com/discord/discord-api-docs/pull/7010) without conflicts.

Example:
```python
async def cog_load(self) -> None:
    emoji_dir = self.module.path / "emojis"
    await self.module.register_emoji(emoji_dir / "miku.png")
```


### Extra information
At the moment, old registered emojis will not be deleted.
The implementation is still very WIP, but I want feedback on the API.
